### PR TITLE
update PDK to v3.6.1 / raise resource coverage to 100%

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,13 +9,9 @@ on:
 jobs:
   Spec:
     uses: "puppetlabs/cat-github-actions/.github/workflows/module_ci.yml@main"
-    with:
-      flags: "--nightly"
     secrets: "inherit"
 
   Acceptance:
     needs: Spec
     uses: "puppetlabs/cat-github-actions/.github/workflows/module_acceptance.yml@main"
-    with:
-      flags: "--nightly"
     secrets: "inherit"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -13,6 +13,4 @@ jobs:
   Acceptance:
     needs: Spec
     uses: "puppetlabs/cat-github-actions/.github/workflows/module_acceptance.yml@main"
-    with:
-      flags: '--nightly'
     secrets: "inherit"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,10 @@
 ---
-require:
+plugins:
 - rubocop-performance
 - rubocop-rspec
+- rubocop-rspec_rails
+- rubocop-factory_bot
+- rubocop-capybara
 AllCops:
   NewCops: enable
   DisplayCopNames: true
@@ -120,6 +123,12 @@ Bundler/InsecureProtocolSource:
 Capybara/CurrentPathExpectation:
   Enabled: false
 Capybara/VisibilityMatcher:
+  Enabled: false
+FactoryBot/AttributeDefinedStatically:
+  Enabled: false
+FactoryBot/CreateList:
+  Enabled: false
+FactoryBot/FactoryClassName:
   Enabled: false
 Gemspec/DuplicatedAssignment:
   Enabled: false
@@ -295,8 +304,6 @@ Performance/UriDefaultParser:
   Enabled: false
 RSpec/Be:
   Enabled: false
-RSpec/Capybara/FeatureMethods:
-  Enabled: false
 RSpec/ContainExactly:
   Enabled: false
 RSpec/ContextMethod:
@@ -304,6 +311,8 @@ RSpec/ContextMethod:
 RSpec/ContextWording:
   Enabled: false
 RSpec/DescribeClass:
+  Enabled: false
+RSpec/Dialect:
   Enabled: false
 RSpec/EmptyHook:
   Enabled: false
@@ -320,12 +329,6 @@ RSpec/ExampleWithoutDescription:
 RSpec/ExpectChange:
   Enabled: false
 RSpec/ExpectInHook:
-  Enabled: false
-RSpec/FactoryBot/AttributeDefinedStatically:
-  Enabled: false
-RSpec/FactoryBot/CreateList:
-  Enabled: false
-RSpec/FactoryBot/FactoryClassName:
   Enabled: false
 RSpec/HooksBeforeExamples:
   Enabled: false
@@ -501,6 +504,12 @@ Capybara/SpecificFinders:
   Enabled: false
 Capybara/SpecificMatcher:
   Enabled: false
+FactoryBot/ConsistentParenthesesStyle:
+  Enabled: false
+FactoryBot/FactoryNameStyle:
+  Enabled: false
+FactoryBot/SyntaxMethods:
+  Enabled: false
 Gemspec/DeprecatedAttributeAssignment:
   Enabled: false
 Gemspec/DevelopmentDependencies:
@@ -601,27 +610,11 @@ RSpec/DuplicatedMetadata:
   Enabled: false
 RSpec/ExcessiveDocstringSpacing:
   Enabled: false
-RSpec/FactoryBot/ConsistentParenthesesStyle:
-  Enabled: false
-RSpec/FactoryBot/FactoryNameStyle:
-  Enabled: false
-RSpec/FactoryBot/SyntaxMethods:
-  Enabled: false
 RSpec/IdenticalEqualityAssertion:
   Enabled: false
 RSpec/NoExpectationExample:
   Enabled: false
 RSpec/PendingWithoutReason:
-  Enabled: false
-RSpec/Rails/AvoidSetupHook:
-  Enabled: false
-RSpec/Rails/HaveHttpStatus:
-  Enabled: false
-RSpec/Rails/InferredSpecType:
-  Enabled: false
-RSpec/Rails/MinitestAssertions:
-  Enabled: false
-RSpec/Rails/TravelAround:
   Enabled: false
 RSpec/RedundantAround:
   Enabled: false
@@ -632,6 +625,16 @@ RSpec/SortMetadata:
 RSpec/SubjectDeclaration:
   Enabled: false
 RSpec/VerifiedDoubleReference:
+  Enabled: false
+RSpecRails/AvoidSetupHook:
+  Enabled: false
+RSpecRails/HaveHttpStatus:
+  Enabled: false
+RSpecRails/InferredSpecType:
+  Enabled: false
+RSpecRails/MinitestAssertions:
+  Enabled: false
+RSpecRails/TravelAround:
   Enabled: false
 Security/CompoundHash:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -52,9 +52,13 @@ group :development do
   gem "pry", '~> 0.10',                          require: false
   gem "simplecov-console", '~> 0.9',             require: false
   gem "puppet-debugger", '~> 1.6',               require: false
-  gem "rubocop", '~> 1.50.0',                    require: false
-  gem "rubocop-performance", '= 1.16.0',         require: false
-  gem "rubocop-rspec", '= 2.19.0',               require: false
+  gem "rubocop", '~> 1.73.0',                    require: false
+  gem "rubocop-performance", '~> 1.24.0',        require: false
+  gem "rubocop-rspec", '~> 3.5.0',               require: false
+  gem "rubocop-rspec_rails", '~> 2.31.0',        require: false
+  gem "rubocop-factory_bot", '~> 2.27.0',        require: false
+  gem "rubocop-capybara", '~> 2.22.0',           require: false
+  gem "rubocop-ast", '< 1.43.0',                 require: false, platforms: [:mswin, :mingw, :x64_mingw]
   gem "rb-readline", '= 0.5.5',                  require: false, platforms: [:mswin, :mingw, :x64_mingw]
   gem "bigdecimal", '< 3.2.2',                   require: false, platforms: [:mswin, :mingw, :x64_mingw]
 end
@@ -71,10 +75,12 @@ group :system_tests do
 end
 
 gems = {}
+bolt_version = ENV.fetch('BOLT_GEM_VERSION', nil)
 puppet_version = ENV.fetch('PUPPET_GEM_VERSION', nil)
 facter_version = ENV.fetch('FACTER_GEM_VERSION', nil)
 hiera_version = ENV.fetch('HIERA_GEM_VERSION', nil)
 
+gems['bolt'] = location_for(bolt_version, nil, { source: gemsource_puppetcore })
 gems['puppet'] = location_for(puppet_version, nil, { source: gemsource_puppetcore })
 gems['facter'] = location_for(facter_version, nil, { source: gemsource_puppetcore })
 gems['hiera'] = location_for(hiera_version, nil, {}) if hiera_version

--- a/lib/puppet/type/concat_fragment.rb
+++ b/lib/puppet/type/concat_fragment.rb
@@ -101,6 +101,6 @@ Puppet::Type.newtype(:concat_fragment) do
       sensitive_parameters.delete(:content)
       parameter(:content).sensitive = true
     end
-    super(sensitive_parameters)
+    super
   end
 end

--- a/metadata.json
+++ b/metadata.json
@@ -109,6 +109,6 @@
     }
   ],
   "template-url": "https://github.com/puppetlabs/pdk-templates.git#main",
-  "template-ref": "heads/main-0-g9d5b193",
-  "pdk-version": "3.5.0"
+  "template-ref": "heads/main-0-g6a9a73d",
+  "pdk-version": "3.6.1"
 }

--- a/spec/acceptance/concat_spec.rb
+++ b/spec/acceptance/concat_spec.rb
@@ -51,8 +51,8 @@ describe 'basic concat test' do
       idempotent_apply(pp)
       expect(file("#{basedir}/file")).to be_file
       expect(file("#{basedir}/file")).to be_owned_by username unless os[:family] == 'windows'
-      expect(file("#{basedir}/file")).to be_grouped_into groupname unless os[:family] == 'windows' || os[:family] == 'darwin'
-      expect(file("#{basedir}/file")).to be_mode 644 unless os[:family] == 'aix' || os[:family] == 'windows'
+      expect(file("#{basedir}/file")).to be_grouped_into groupname unless ['windows', 'darwin'].include?(os[:family])
+      expect(file("#{basedir}/file")).to be_mode 644 unless ['aix', 'windows'].include?(os[:family])
       expect(file("#{basedir}/file").content).to match '1'
       expect(file("#{basedir}/file").content).to match '2'
     end
@@ -77,7 +77,7 @@ describe 'basic concat test' do
     it 'idempotent, file matches' do
       idempotent_apply(pp)
       expect(file("#{basedir}/file")).to be_file
-      expect(file("#{basedir}/file")).to be_mode 644 unless os[:family] == 'aix' || os[:family] == 'windows'
+      expect(file("#{basedir}/file")).to be_mode 644 unless ['aix', 'windows'].include?(os[:family])
       expect(file("#{basedir}/file").content).to match '1'
     end
   end
@@ -161,7 +161,7 @@ describe 'basic concat test' do
     it 'idempotent, file matches' do
       idempotent_apply(pp)
       expect(file("#{basedir}/#{filename}")).to be_file
-      expect(file("#{basedir}/#{filename}")).to be_mode 644 unless os[:family] == 'aix' || os[:family] == 'windows'
+      expect(file("#{basedir}/#{filename}")).to be_mode 644 unless ['aix', 'windows'].include?(os[:family])
       expect(file("#{basedir}/#{filename}").content).to match '1'
     end
   end

--- a/spec/acceptance/fragment_replace_spec.rb
+++ b/spec/acceptance/fragment_replace_spec.rb
@@ -109,7 +109,7 @@ describe 'replacement of' do
 
     it 'when symlink should not succeed' do
       idempotent_apply(pp)
-      expect(file("#{basedir}/file")).to be_linked_to "#{basedir}/dangling" unless os[:family] == 'aix' || os[:family] == 'windows'
+      expect(file("#{basedir}/file")).to be_linked_to "#{basedir}/dangling" unless ['aix', 'windows'].include?(os[:family])
       expect(file("#{basedir}/dangling")).not_to be_file
       expect(file("#{basedir}/dangling")).not_to be_directory
     end

--- a/spec/defines/concat_spec.rb
+++ b/spec/defines/concat_spec.rb
@@ -55,6 +55,10 @@ describe 'concat' do
     if p[:ensure] == 'present'
       it do
         expect(subject).to contain_concat(title).with(file_defaults.merge(present_expect))
+        expect(subject).to contain_concat_file(title)
+        if p[:warn] != false
+          expect(subject).to contain_concat_fragment('/etc/foo.bar_header')
+        end
       end
     else
       it do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,7 +26,7 @@ default_fact_files.each do |f|
 
   begin
     require 'deep_merge'
-    default_facts.deep_merge!(YAML.safe_load(File.read(f), permitted_classes: [], permitted_symbols: [], aliases: true))
+    default_facts.deep_merge!(YAML.safe_load_file(f, permitted_classes: [], permitted_symbols: [], aliases: true))
   rescue StandardError => e
     RSpec.configuration.reporter.message "WARNING: Unable to load #{f}: #{e}"
   end


### PR DESCRIPTION
## Summary
This PR updates the used PDK version to v3.6.1 and fixes the rubocop errors.
Additionally, it raises the resource coverage to 100%

## Additional Context
These changes are as minimal as possible.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)